### PR TITLE
Use fast scroll for long lists of things

### DIFF
--- a/subsonic-android/res/layout/download_playlist.xml
+++ b/subsonic-android/res/layout/download_playlist.xml
@@ -13,12 +13,13 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:padding="10dip"/>
-
+
     <ListView
-            android:id="@+id/download_list"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_weight="1"
-            android:cacheColorHint="#00000000"/>
+        android:id="@+id/download_list"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:cacheColorHint="#00000000"
+        android:fastScrollEnabled="true" />
 
 </LinearLayout>

--- a/subsonic-android/res/layout/select_album.xml
+++ b/subsonic-android/res/layout/select_album.xml
@@ -20,12 +20,14 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:padding="10dip"/>
-
-    <ListView android:id="@+id/select_album_entries"
-              android:textFilterEnabled="true"
-              android:layout_width="fill_parent"
-              android:layout_height="0dip"
-              android:layout_weight="1.0"/>
+
+    <ListView
+        android:id="@+id/select_album_entries"
+        android:layout_width="fill_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1.0"
+        android:fastScrollEnabled="true"
+        android:textFilterEnabled="true" />
 
     <LinearLayout android:orientation="horizontal"
                   android:layout_marginTop="6dp"

--- a/subsonic-android/res/layout/select_playlist.xml
+++ b/subsonic-android/res/layout/select_playlist.xml
@@ -20,11 +20,13 @@
             android:layout_height="wrap_content"
             android:padding="10dip"
             android:visibility="gone"/>
-
-    <ListView android:id="@+id/select_playlist_list"
-              android:layout_width="fill_parent"
-              android:layout_height="0dip"
-              android:layout_weight="1.0"/>
+
+    <ListView
+        android:id="@+id/select_playlist_list"
+        android:layout_width="fill_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1.0"
+        android:fastScrollEnabled="true" />
 
     <include layout="@layout/button_bar"/>
 


### PR DESCRIPTION
Enables fast scroll (large scroll tab on the side of the screen used to
quickly move along a large list) for the Media Library activity
and Playlist activity. This works for lists of folders, albums, or
individual tracks. Fast scroll was already enabled for the artist list.

Simple change to fix the issue reported in http://forum.subsonic.org/forum/viewtopic.php?f=3&t=7188
