### PR TITLE
Stop autoremoval of tracknumbers from title tag

### DIFF
--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/metadata/MetaDataParser.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/metadata/MetaDataParser.java
@@ -59,7 +59,6 @@ public abstract class MetaDataParser {
             title = guessTitle(file);
         }
 
-        title = removeTrackNumberFromTitle(title, metaData.getTrackNumber());
         metaData.setArtist(artist);
         metaData.setAlbumName(album);
         metaData.setTitle(title);


### PR DESCRIPTION
This behavior breaks with albums such as NIN's Ghosts I-IV which tracks are "01 Ghosts I", "24 Ghosts III" etc. Tracks end up being displayed and scrobbed as "Ghosts I", "Ghosts II", "Ghosts III", or "Ghosts IV".
