### PR TITLE
Modify start scripts and fix deb installer

### DIFF
--- a/subsonic-assembly/src/main/assembly/standalone.xml
+++ b/subsonic-assembly/src/main/assembly/standalone.xml
@@ -34,8 +34,8 @@
             <directory>../subsonic-booter/src/main/script</directory>
             <outputDirectory/>
             <includes>
-                <include>subsonic.sh</include>
-                <include>subsonic.bat</include>
+                <include>supersonic.sh</include>
+                <include>supersonic.bat</include>
             </includes>
             <fileMode>0777</fileMode>
         </fileSet>

--- a/subsonic-booter/src/main/script/supersonic.bat
+++ b/subsonic-booter/src/main/script/supersonic.bat
@@ -20,5 +20,5 @@ set SUPERSONIC_CONTEXT_PATH=/
 REM  The memory limit (max Java heap size) in megabytes.
 set MAX_MEMORY=100
 
-java -Xmx%MAX_MEMORY%m  -Dsubsonic.home=%SUPERSONIC_HOME% -Dsubsonic.host=%SUPERSONIC_HOST% -Dsubsonic.port=%SUPERSONIC_PORT%  -Dsubsonic.httpsPort=%SUPERSONIC_HTTPS_PORT% -Dsubsonic.contextPath=%SUPERSONIC_CONTEXT_PATH% -jar subsonic-booter-jar-with-dependencies.jar
+java -Xmx%MAX_MEMORY%m  -Dsubsonic.home=%SUPERSONIC_HOME% -Dsubsonic.host=%SUPERSONIC_HOST% -Dsubsonic.port=%SUPERSONIC_PORT%  -Dsubsonic.httpsPort=%SUPERSONIC_HTTPS_PORT% -Dsubsonic.contextPath=%SUPERSONIC_CONTEXT_PATH% -jar supersonic-booter-jar-with-dependencies.jar
 

--- a/subsonic-booter/src/main/script/supersonic.sh
+++ b/subsonic-booter/src/main/script/supersonic.sh
@@ -20,7 +20,7 @@ SUPERSONIC_DEFAULT_PLAYLIST_FOLDER=/var/playlists
 quiet=0
 
 usage() {
-    echo "Usage: subsonic.sh [options]"
+    echo "Usage: supersonic.sh [options]"
     echo "  --help               This small usage guide."
     echo "  --home=DIR           The directory where Supersonic will create files."
     echo "                       Make sure it is writable. Default: /var/supersonic"
@@ -121,7 +121,7 @@ ${JAVA} -Xmx${SUPERSONIC_MAX_MEMORY}m \
   -Dsubsonic.defaultPlaylistFolder=${SUPERSONIC_DEFAULT_PLAYLIST_FOLDER} \
   -Djava.awt.headless=true \
   -verbose:gc \
-  -jar subsonic-booter-jar-with-dependencies.jar > ${LOG} 2>&1 &
+  -jar supersonic-booter-jar-with-dependencies.jar > ${LOG} 2>&1 &
 
 # Write pid to pidfile if it is defined.
 if [ $SUPERSONIC_PIDFILE ]; then

--- a/subsonic-installer-debian/pom.xml
+++ b/subsonic-installer-debian/pom.xml
@@ -41,8 +41,8 @@
                                             </filterset>
                                         </copy>
 
-                                        <copy file="../subsonic-booter/src/main/script/subsonic.sh" todir="${project.build.directory}/deb/usr/share/supersonic"/>
-                                        <copy file="../subsonic-booter/target/subsonic-booter-jar-with-dependencies.jar" todir="${project.build.directory}/deb/usr/share/supersonic"/>
+                                        <copy file="../subsonic-booter/src/main/script/supersonic.sh" todir="${project.build.directory}/deb/usr/share/supersonic"/>
+                                        <copy file="../subsonic-booter/target/supersonic-booter-jar-with-dependencies.jar" todir="${project.build.directory}/deb/usr/share/supersonic"/>
                                         <copy file="../subsonic-main/target/supersonic.war" todir="${project.build.directory}/deb/usr/share/supersonic"/>
                                         <copy file="../subsonic-transcode/linux/ffmpeg" todir="${project.build.directory}/deb/var/supersonic/transcode"/>
                                         <copy file="../subsonic-transcode/linux/lame" todir="${project.build.directory}/deb/var/supersonic/transcode"/>
@@ -53,7 +53,7 @@
                                             <arg value="${project.build.directory}/deb/DEBIAN/postinst"/>
                                             <arg value="${project.build.directory}/deb/DEBIAN/prerm"/>
                                             <arg value="${project.build.directory}/deb/DEBIAN/postrm"/>
-                                            <arg value="${project.build.directory}/deb/usr/share/supersonic/subsonic.sh"/>
+                                            <arg value="${project.build.directory}/deb/usr/share/supersonic/supersonic.sh"/>
                                             <arg value="${project.build.directory}/deb/etc/init.d/supersonic"/>
                                             <arg value="${project.build.directory}/deb/var/supersonic/transcode/ffmpeg"/>
                                             <arg value="${project.build.directory}/deb/var/supersonic/transcode/lame"/>


### PR DESCRIPTION
There was a mix of "sub" and "super" suffixes in the pom.xml file and this was causing the deb to be incorrectly put together.
