### PR TITLE
when creating sort name ignore non-alphanumeric and convert '_' to space

### DIFF
--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/MusicIndexService.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/MusicIndexService.java
@@ -180,12 +180,14 @@ public class MusicIndexService {
     }
 
     private String createSortableName(String name, String[] ignoredArticles) {
+        name = name.replaceAll("[^\\p{L}\\p{N} ]+"," ").trim();
         String uppercaseName = name.toUpperCase();
         for (String article : ignoredArticles) {
             if (uppercaseName.startsWith(article.toUpperCase() + " ")) {
                 return name.substring(article.length() + 1) + ", " + article;
             }
         }
+
         return name;
     }
 


### PR DESCRIPTION
This is to address issue #24. When creating a sort name it replaces all Unicode characters that are not letters or numbers with spaces and then trims. This accounts for artists with punctuation in their name. It may be worth replacing umlauted and other special versions with their plain ascii version. I don't know enough about other languages to say if that's a reasonable behavior.
