### PR TITLE
Update INSTALL to use maven's -U switch in case of dependency issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target/
 *.jar
 *.war
 *.ear
+.project
+.settings
+.classpath

--- a/INSTALL
+++ b/INSTALL
@@ -29,6 +29,8 @@ Maven to install a binary package for your distribution:
 cd <supersonic source folder>
 mvn clean -P full; mvn install -P full
 
+If case of dependency issues, try
+mvn install -P full -U 
 
 Then install the now built binary package for your distribution:
 


### PR DESCRIPTION
Hi, as discussed on mailing list, I did a fresh checkout of the project and had some dependency resolution issues which were fixed with using the -U switch. 
I updated the install file accordingly.

Another change, I modified the .gitignore file to ignore personal eclipse settings files: 
.project, .settings and .classpath so project is independent of IDE used. Just thought it might be useful, but feel free to ignore. 
Thank you.
