### PR TITLE
Fixed a crash for podcastservice

### DIFF
--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
@@ -208,14 +208,21 @@ public class PodcastService {
     }
 
     private void addMediaFileIdToEpisodes(List<PodcastEpisode> episodes) {
-        for (PodcastEpisode episode : episodes) {
-            if (episode.getPath() != null) {
-                MediaFile mediaFile = mediaFileService.getMediaFile(episode.getPath());
-                if (mediaFile != null) {
-                    episode.setMediaFileId(mediaFile.getId());
-                }
-            }
-        }
+    	for (PodcastEpisode episode : episodes) {
+    		try {
+    			if (episode.getPath() != null) {
+    				MediaFile mediaFile = mediaFileService.getMediaFile(episode.getPath());
+    				if (mediaFile != null) {
+    					episode.setMediaFileId(mediaFile.getId());
+    				}
+    			}
+    		}
+    		// If there was an error loading an episode, remove it.
+    		catch (Exception e) {
+    			podcastDao.deleteEpisode(episode.getId());
+			LOG.info("Deleted Podcast episode '" + episode.getTitle() + "' because:" e.getMessage());
+    		}
+    	}
     }
 
     private PodcastEpisode getEpisode(int channelId, String url) {

--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
@@ -100,7 +100,7 @@ public class PodcastService {
             for (PodcastEpisode episode : getEpisodes(channel.getId(), false)) {
                 if (episode.getStatus() == PodcastStatus.DOWNLOADING) {
                     deleteEpisode(episode.getId(), false);
-                    LOG.info("Deleted Podcast episode '" + episode.getTitle() + "' since download was interrupted.");
+                    LOG.warn("Deleted Podcast episode '" + episode.getTitle() + "' since download was interrupted.");
                 }
             }
         }

--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
@@ -218,7 +218,7 @@ public class PodcastService {
     			}
     		}
     		// If there was an error loading an episode, remove it.
-    		catch (Exception e) {
+    		catch (SecurityException e) {
     			podcastDao.deleteEpisode(episode.getId());
 			LOG.info("Deleted Podcast episode '" + episode.getTitle() + "' because:" e.getMessage());
     		}

--- a/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
+++ b/subsonic-main/src/main/java/net/sourceforge/subsonic/service/PodcastService.java
@@ -208,14 +208,20 @@ public class PodcastService {
     }
 
     private void addMediaFileIdToEpisodes(List<PodcastEpisode> episodes) {
-        for (PodcastEpisode episode : episodes) {
-            if (episode.getPath() != null) {
-                MediaFile mediaFile = mediaFileService.getMediaFile(episode.getPath());
-                if (mediaFile != null) {
-                    episode.setMediaFileId(mediaFile.getId());
-                }
-            }
-        }
+    	for (PodcastEpisode episode : episodes) {
+    		try {
+    			if (episode.getPath() != null) {
+    				MediaFile mediaFile = mediaFileService.getMediaFile(episode.getPath());
+    				if (mediaFile != null) {
+    					episode.setMediaFileId(mediaFile.getId());
+    				}
+    			}
+    		}
+    		// If there was an error loading an episode, remove it.
+    		catch (Exception e) {
+    			podcastDao.deleteEpisode(episode.getId());
+    		}
+    	}
     }
 
     private PodcastEpisode getEpisode(int channelId, String url) {


### PR DESCRIPTION
If the filespaths stored in the podcastDoa DB pointed to paths which the server could not open, the whole server crashed. Fixed this little error by, somewhat naively, catching all the exceptions thrown and removing the offending episodes from the DB.
